### PR TITLE
CORE-8162 Add job stats to add-app-listing-base-query-fields.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,4 +19,4 @@
                         ["snapshots" :clojars]]
   :eastwood {:exclude-namespaces [apps.protocols :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
-  :manifest {"db-version" "2.8.0:20160728.01"})
+  :manifest {"db-version" "2.9.0:20161007.01"})

--- a/src/kameleon/app_listing.clj
+++ b/src/kameleon/app_listing.clj
@@ -134,6 +134,11 @@
           :tool_count
           :external_app_count
           :task_count
+          :job_count
+          :job_count_completed
+          :job_count_failed
+          :job_last_completed
+          :last_used
           :deleted
           :disabled
           :overall_job_type))

--- a/src/kameleon/sql_reader.clj
+++ b/src/kameleon/sql_reader.clj
@@ -1,6 +1,6 @@
 (ns kameleon.sql-reader
   (:use [clojure.java.io :only [file reader]]
-        [korma.core]
+        [korma.core :exclude [update]]
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]


### PR DESCRIPTION
Adds the new `app_listing` view job stat columns to apps listing queries, and adds the db version, added by cyverse-de/de-db#1.
