### PR TITLE
CORE-1997 Allow more precision in db/millis-from-str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pom.xml.asc
 /bin
 test2junit
 build.xml
+*.iml

--- a/src/kameleon/db.clj
+++ b/src/kameleon/db.clj
@@ -1,8 +1,7 @@
 (ns kameleon.db
   (:use [korma.core :exclude [update]]
         [korma.db])
-  (:require [clj-time.coerce :as tc]
-            [clj-time.core :as t]
+  (:require [clj-time.core :as t]
             [clj-time.format :as tf]
             [clojure.string :as string])
   (:import [java.sql Timestamp]))
@@ -17,7 +16,7 @@
     "YYYY MMM dd HH:mm:ss"
     "YYYY-MM-dd-HH-mm-ss.SSS"
     "YYYY-MM-dd HH:mm:ss.SSS"
-    "YYYY-MM-dd'T'HH:mm:ss.SSSZ"))
+    "YYYY-MM-dd'T'HH:mm:ss.SSSSSSSSSZ"))
 
 (defn- strip-time-zone
   "Removes the time zone abbreviation from a date timestamp."


### PR DESCRIPTION
Tapis v3 timestamps can have 9 decimal digits in job status callbacks.

Added more seconds decimal digits in `db/timestamp-parser` (used by `db/millis-from-str`), which still allows parsing seconds with only millisecond precision.